### PR TITLE
Change id calculation in Purchase objects generation

### DIFF
--- a/Module_6/kafka-streams-examples/src/main/java/com/luxoft/eas026/streams/PurchaseStatisticsDriver.java
+++ b/Module_6/kafka-streams-examples/src/main/java/com/luxoft/eas026/streams/PurchaseStatisticsDriver.java
@@ -30,7 +30,7 @@ public class PurchaseStatisticsDriver {
 			for (int j = 0; j < 10; j++) {
 				final String product = products[new Random().nextInt(products.length)];
 				final int customer = new Random().nextInt(3);
-				Purchase purchase = Purchase.newBuilder().setId(id++).setProduct(product).setAmount(1).setSum(10)
+				Purchase purchase = Purchase.newBuilder().setId(++id).setProduct(product).setAmount(1).setSum(10)
 						.setCustomerId(customer).build();
 				producer.send(new ProducerRecord<>("Purchases", String.valueOf(id), purchase));
 


### PR DESCRIPTION
In JoinPurchasePayments example the Payments stream keys are being substituted with purchaseIds. This implies that the Purchases keys and ids must be equal in order to produce the correct join result. This condition was not met due to the use of the post-increment operator in id calculation.